### PR TITLE
fix: add private function for llm request

### DIFF
--- a/pkg/externalfunctions/externalfunctions.go
+++ b/pkg/externalfunctions/externalfunctions.go
@@ -1245,6 +1245,8 @@ func AnsysGPTPerformLLMRephraseRequest(template string, query string, history []
 
 	if len(history) >= 1 {
 		historyMessages += "user:" + history[len(history)-2].Content + "\n"
+	} else {
+		return query
 	}
 
 	// Create map for the data to be used in the template
@@ -1257,7 +1259,11 @@ func AnsysGPTPerformLLMRephraseRequest(template string, query string, history []
 	fmt.Println("System template:", userTemplate)
 
 	// Perform the general request
-	rephrasedQuery, _ = PerformGeneralRequest(userTemplate, nil, false, "You are AnsysGPT, a technical support assistant that is professional, friendly and multilingual that generates a clear and concise answer")
+	rephrasedQuery, _, err := performGeneralRequest(userTemplate, nil, false, "You are AnsysGPT, a technical support assistant that is professional, friendly and multilingual that generates a clear and concise answer")
+	if err != nil {
+		panic(err)
+	}
+
 	fmt.Println("Rephrased query:", rephrasedQuery)
 
 	return rephrasedQuery


### PR DESCRIPTION
- Avoid calling the ``llm`` when no history is passed to the function.
- Add private function until error handling is modified. External functions should not call other external functions.